### PR TITLE
Add support for new sjasmplus directives

### DIFF
--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -40,7 +40,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.asm",
-					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd|nex)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|labelslist|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
+					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd|nex)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|labelslist|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix|opt)\\b)"
 				},
 				{
 					"name": "keyword.control.asm",

--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -40,7 +40,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.asm",
-					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
+					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd|nex)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|labelslist|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix)\\b)"
 				},
 				{
 					"name": "keyword.control.asm",

--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -75,6 +75,10 @@
 					"match": "(?i:(?<=\\s)(?:list|nolist|let)\\b)"
 				},
 				{
+					"name": "keyword.control.asm",
+					"match": "(?i:(?<=\\s)(?:setbp|setbreakpoint|bplist)\\b)"
+				},
+				{
 					"name": "string.other.lua.asm",
 					"begin": "(?i:(?<=\\s)(lua)\\b)",
 					"beginCaptures": {

--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -76,7 +76,7 @@
 				},
 				{
 					"name": "keyword.control.asm",
-					"match": "(?i:(?<=\\s)(?:setbp|setbreakpoint|bplist)\\b)"
+					"match": "(?i:(?<=\\s)(?:setb(p|reakpoint)|bplist)\\b)"
 				},
 				{
 					"name": "string.other.lua.asm",

--- a/src/CompletionProposalsProvider.ts
+++ b/src/CompletionProposalsProvider.ts
@@ -53,7 +53,9 @@ const completions = [
     'textarea',
     'define', 'undefine',
     'device', 'ZXSPECTRUM48', 'ZXSPECTRUM128', 'ZXSPECTRUM256', 'ZXSPECTRUM512', 'ZXSPECTRUM1024', 'ZXSPECTRUMNEXT', 'NONE',
-    'open', 'close' 
+    'open', 'close',
+    'setbp', 'setbreakpoint',
+    'bplist', 'unreal', 'zesarux'
 ];
 
 

--- a/src/CompletionProposalsProvider.ts
+++ b/src/CompletionProposalsProvider.ts
@@ -55,7 +55,8 @@ const completions = [
     'device', 'ZXSPECTRUM48', 'ZXSPECTRUM128', 'ZXSPECTRUM256', 'ZXSPECTRUM512', 'ZXSPECTRUM1024', 'ZXSPECTRUMNEXT', 'NONE',
     'open', 'close',
     'setbp', 'setbreakpoint',
-    'bplist', 'unreal', 'zesarux'
+    'bplist', 'unreal', 'zesarux',
+    'opt'
 ];
 
 


### PR DESCRIPTION
Add support for new sjasmplus 1.14.6 directives:
- **BPLIST**
- **SETBP** (alias **SETBREAKPOINT**)

Add missing highlighting to:
- **SAVENEX**
- **LABELSLIST**
- **OPT**

