### PR TITLE
Add support for all remaining SjASMPlus directives

### DIFF
--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -40,15 +40,15 @@
 			"patterns": [
 				{
 					"name": "keyword.control.asm",
-					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|hob|sna|tap|trd|nex)|empty(tap|trd)|inc(bin|hob|trd)|b?include|insert|labelslist|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix|opt)\\b)"
+					"match": "(?i:(?<=\\s)(?:equ|eval|org|end?t|align|(de|un)?phase|shift|save(bin|dev|hob|sna|tap|trd|nex)|empty(tap|trd)|inc(bin|hob|trd)|b?include|includelua|insert|labelslist|binary|end|output|tap(out|end)|fpos|page|slot|size|outradix|opt)\\b)"
 				},
 				{
 					"name": "keyword.control.asm",
-					"match": "(?i:(?<=\\s)(?:cpu|device|encoding|charset|proc|macro|local|shared|public|rept|dup|block|endm|endp|edup|exitm|module|endmod(ule)?|(un)?define|export|disp|textarea|map|field|defarray)\\b)"
+					"match": "(?i:(?<=\\s)(?:cpu|device|encoding|charset|proc|macro|local|shared|public|rept|dup|block|end[mpr]|edup|exitm|module|endmod(ule)?|(un)?define|export|disp|textarea|(memory|cspect)?map|mmu|field|defarray)\\b)"
 				},
 				{
 					"name": "keyword.control.asm",
-					"match": "(?i:(?<=\\s)(?:assert|fatal|error|warning|message|display|shellexec|def[bdglmswir]|d[bcdghszw]|abyte[cz]?|byte|word|dword|hex)\\b)"
+					"match": "(?i:(?<=\\s)(?:assert|fatal|error|warning|message|display|shellexec|def[bdghlmswir]|d[bcdghmszw]|d24|abyte[cz]?|byte|word|dword|hex)\\b)"
 				},
 				{
 					"name": "keyword.control.asm",
@@ -77,6 +77,10 @@
 				{
 					"name": "keyword.control.asm",
 					"match": "(?i:(?<=\\s)(?:setb(p|reakpoint)|bplist)\\b)"
+				},
+				{
+					"name": "keyword.control.asm",
+					"match": "(?i:(?<=\\s)(?:_(sjasmplus|version|release|errors|warnings))\\b)"
 				},
 				{
 					"name": "string.other.lua.asm",

--- a/src/CompletionProposalsProvider.ts
+++ b/src/CompletionProposalsProvider.ts
@@ -4,7 +4,7 @@ import { grepMultiple, reduceLocations, getCompleteLabel, GrepLocation, getModul
 import { CodeLensProvider } from './CodeLensProvider';
 import { stringify } from 'querystring';
 import { regexPrepareFuzzy } from './regexes';
-import {regexEveryLabelColonForWord, regexEveryLabelWithoutColonForWord, regexEveryModuleForWord, regexEveryMacroForWord } from './regexes';
+import { regexEveryLabelColonForWord, regexEveryLabelWithoutColonForWord, regexEveryModuleForWord, regexEveryMacroForWord } from './regexes';
 
 
 /// All additional completions like Z80 instructions and assembler
@@ -33,30 +33,37 @@ const completions = [
     'bsla', 'bsra', 'bsrl', 'bsrf', 'brlc',
 
     // sjasmplus fake instructions
-    'ldi',
+    'sli',
 
     // sjasmplus
     'macro', 'endm', 'module', 'endmodule', 'struct', 'ends', 'dup', 'edup',
     'if', 'ifn', 'ifdef', 'ifndef', 'ifused', 'ifnused', 'else', 'endif',
     'include', 'incbin',
-    'abyte', 'abytec', 'abytez', 'align', 'assert', 
-    'binary', 'block', 'defb', 'defg', 'defw', 'defm', 'defs', 'dephase', 'disp', 'dh', 'hex', 'dg',
-    'display', 'byte', 'word', 'dword', 
-    'emptytap', 'emptytrd', 
-    'equ', 'export', 
+    'abyte', 'abytec', 'abytez', 'align', 'assert',
+    'binary', 'block', 'defb', 'defd', 'defg', 'defh', 'defl', 'defm', 'defs', 'defw', 'dephase', 'disp', 'phase', 'unphase',
+    'd24', 'db', 'dc', 'dd', 'dg', 'dh', 'hex', 'dm', 'ds', 'dw', 'dz',
+    'display', 'byte', 'word', 'dword',
+    'emptytap', 'emptytrd', 'encoding',
+    'equ', 'export',
     'end', 'endlua', 'endt', 'ent',
-    'incbin', 'includelua', 'inctrd', 'insert', 
-    'lua', 'org', 'outend', 'output',
-    'page', 'rept', 'savebin', 'savesna', 'savetap', 'savetrd', 'savenex',
-    'shellexec', 'size', 'slot', 
+    'includelua', 'inchob', 'inctrd', 'insert',
+    'lua', 'labelslist', 'org', 'outend', 'output',
+    'memorymap', 'mmu',
+    'page', 'rept', 'endr', 'savebin', 'savedev', 'savehob', 'savesna', 'savetrd',
+    'savetap', 'basic', 'code', 'numbers', 'chars', 'headless',
+    'savenex', 'core', 'cfg', 'cfg3', 'bar', 'palette', 'default', 'mem', 'bmp', 'screen',
+    'l2', 'l2_320', 'l2_640', 'scr', 'shc', 'shr', 'tile', 'cooper', 'bank', 'auto',
+    'shellexec', 'size', 'slot',
     'tapend', 'tapout',
     'textarea',
     'define', 'undefine',
+    'defarray', 'defarray+',
     'device', 'ZXSPECTRUM48', 'ZXSPECTRUM128', 'ZXSPECTRUM256', 'ZXSPECTRUM512', 'ZXSPECTRUM1024', 'ZXSPECTRUM2048', 'ZXSPECTRUM4096', 'ZXSPECTRUM8192', 'ZXSPECTRUMNEXT', 'NONE', 'ramtop',
     'open', 'close',
     'setbp', 'setbreakpoint',
     'bplist', 'unreal', 'zesarux',
-    'opt'
+    'opt', 'cspectmap', 'fpos',
+    '_sjasmplus', '_version', '_release', '_errors', '_warnings'
 ];
 
 


### PR DESCRIPTION
I did review SjASMPlus documentation yesterday and have added, I hope, all remaining directives/options/highlighting, including **SAVEDEV, INCLUDELUA, ENDR, MEMORYMAP, CSPECTMAP, MMU, DG, D24, DEFH, _SJASMPLUS, _VERSION, _ERRORS, _WARNINGS** and more.

