### PR TITLE
Adds support to change the line comment prefix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-            //"preLaunchTask": "npm"
+            "preLaunchTask": "npm"
         },
         {
             "name": "Launch Tests",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.6.6
+- Added support for changing the line comment prefix to use with VS Code keybindings: Toggle/Add Line Comment. (asm-code-lens.comments.lineCommentPrefix)
+
 # 1.6.5
 - Icon for hex calculator added.
 - Hex calculator added to test pane.

--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -52,6 +52,11 @@
 					"name": "comment.line_slash.asm",
 					"begin": "//",
 					"end": "\\n"
+				},
+				{
+					"name": "comment.line_hashtag.asm",
+					"begin": "#",
+					"end": "\\n"
 				}
 			]
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "asm-code-lens",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,12 @@
                     "type": "boolean",
                     "scope": "resource",
                     "default": false
+                },
+                "asm-code-lens.comments.lineCommentPrefix": {
+                    "description": "Configure what prefix you want for line comments",
+                    "type": "string",
+                    "scope": "resource",
+                    "default": ";"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asm-code-lens",
     "displayName": "ASM Code Lens",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "publisher": "maziac",
     "description": "A language server that enables code lens, references, hover information, symbol renaming and the outline view for assembler files.",
     "author": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
 /**
  * Reads the confguration.
  */
-function configure(context: vscode.ExtensionContext, event?) {
+function configure(context: vscode.ExtensionContext, event?: vscode.ConfigurationChangeEvent) {
     const settings = vscode.workspace.getConfiguration('asm-code-lens', null);
 
     // Check for the hex calculator params
@@ -90,6 +90,13 @@ function configure(context: vscode.ExtensionContext, event?) {
                 regRenameProvider.dispose();
                 regRenameProvider = undefined;
             }
+        }
+    }
+    if(event) {
+        if(event.affectsConfiguration('asm-code-lens.comments.lineCommentPrefix')) {
+            const commentPrefix = settings.get<string>("comments.lineCommentPrefix");
+            
+            vscode.languages.setLanguageConfiguration("asm-collection", {comments: {lineComment: commentPrefix}});
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,13 +92,6 @@ function configure(context: vscode.ExtensionContext, event?: vscode.Configuratio
             }
         }
     }
-    if(event) {
-        if(event.affectsConfiguration('asm-code-lens.comments.lineCommentPrefix')) {
-            const commentPrefix = settings.get<string>("comments.lineCommentPrefix");
-            
-            vscode.languages.setLanguageConfiguration("asm-collection", {comments: {lineComment: commentPrefix}});
-        }
-    }
 
     // Set search paths.
     setGrepGlobPatterns(settings.includeFiles, settings.excludeFiles);
@@ -214,6 +207,12 @@ function configure(context: vscode.ExtensionContext, event?: vscode.Configuratio
             regDocumentSymbolProvider.dispose();
             regDocumentSymbolProvider=undefined;
         }
+    }
+
+    // Comment configuration
+    if(settings.comments.lineCommentPrefix) {
+        const commentPrefix = settings.get<string>("comments.lineCommentPrefix");
+        vscode.languages.setLanguageConfiguration("asm-collection", {comments: {lineComment: commentPrefix}});
     }
 }
 


### PR DESCRIPTION
This pull request adds an extension setting that enables the user to change which symbol(s) to use as a line comment prefix. It also adds highlighting for '#' by default. The default prefix is still ';' as to not break any configurations by previous users of the extension.