### PR TITLE
Add hover and definition support for CA65-style directives

### DIFF
--- a/src/CompletionProposalsProvider.ts
+++ b/src/CompletionProposalsProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { grepMultiple, reduceLocations, getCompleteLabel, getModule, getNonLocalLabel } from './grep';
 //import { CodeLensProvider } from './CodeLensProvider';
 //import { stringify } from 'querystring';
-import { regexPrepareFuzzy } from './regexes';
+import { regexCA65DirectiveForWord, regexPrepareFuzzy } from './regexes';
 import { regexEveryLabelColonForWord, regexEveryLabelWithoutColonForWord, regexEveryModuleForWord, regexEveryMacroForWord } from './regexes';
 
 
@@ -142,9 +142,11 @@ export class CompletionProposalsProvider implements vscode.CompletionItemProvide
             const searchsJasmModule = regexEveryModuleForWord(searchWord);
             // Find all sjasmplus MACROs in the document
             const searchsJasmMacro = regexEveryMacroForWord(searchWord);
+            // Find all CA65 directives in the document
+            const searchCA65 = regexCA65DirectiveForWord(searchWord, true);
 
 
-            grepMultiple([searchNormal, searchSjasmLabel, searchsJasmModule, searchsJasmMacro])
+            grepMultiple([searchNormal, searchSjasmLabel, searchsJasmModule, searchsJasmMacro, searchCA65])
             //grepMultiple([searchNormal])
             .then(locations => {
                 // Reduce the found locations.

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { grepMultiple, reduceLocations } from './grep';
 //import { resolve } from 'path';
-import { regexInclude, regexLabelColonForWord, regexLabelWithoutColonForWord, regexModuleForWord, regexMacroForWord, regexStructForWord } from './regexes';
+import { regexInclude, regexLabelColonForWord, regexLabelWithoutColonForWord, regexModuleForWord, regexMacroForWord, regexStructForWord, regexCA65DirectiveForWord } from './regexes';
 
 
 
@@ -75,8 +75,10 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
             const searchSjasmMacro = regexMacroForWord(searchWord);
             // Find all sjasmplus STRUCTs in the document
             const searchSjasmStruct = regexStructForWord(searchWord);
+            // Find all CA65 directives in the document
+            const searchCA65 = regexCA65DirectiveForWord(searchWord);
 
-            grepMultiple([searchNormal, searchSjasmLabel, searchSjasmModule, searchSjasmMacro, searchSjasmStruct])
+            grepMultiple([searchNormal, searchSjasmLabel, searchSjasmModule, searchSjasmMacro, searchSjasmStruct, searchCA65])
             //grepMultiple([searchSjasmMacro])
             .then(locations => {
                 reduceLocations(locations, document.fileName, position)

--- a/src/HoverProvider.ts
+++ b/src/HoverProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { grepMultiple, reduceLocations, getCompleteLabel } from './grep';
-import { regexLabelColonForWord, regexLabelWithoutColonForWord, regexModuleForWord, regexMacroForWord } from './regexes';
+import { regexLabelColonForWord, regexLabelWithoutColonForWord, regexModuleForWord, regexMacroForWord, regexCA65DirectiveForWord } from './regexes';
 import * as fs from 'fs';
 //import * as path from 'path';
 
@@ -50,8 +50,10 @@ export class HoverProvider implements vscode.HoverProvider {
             const searchsJasmModule = regexModuleForWord(searchWord);
             // Find all sjasmplus MACROs in the document
             const searchsJasmMacro = regexMacroForWord(searchWord);
+            // Find all CA65 directives in the document
+            const searchCA65 = regexCA65DirectiveForWord(searchWord);
 
-            grepMultiple([searchNormal, searchSjasmLabel, searchsJasmModule, searchsJasmMacro])
+            grepMultiple([searchNormal, searchSjasmLabel, searchsJasmModule, searchsJasmMacro, searchCA65])
 //            grepMultiple([searchSjasmLabel])
             .then(locations => {
                 // Reduce the found locations.

--- a/src/regexes.ts
+++ b/src/regexes.ts
@@ -131,6 +131,15 @@ export function regexStructForWord(searchWord: string): RegExp {
 }
 
 
+/**
+ * Searches for a CA65-style directive that contains the given word.
+ * Capture groups:
+ *  1 = preceding characters before 'searchWord'.
+ * Used by DefinitionProvider, HoverProvider.
+ */
+export function regexCA65DirectiveForWord(searchWord: string): RegExp {
+    return new RegExp('^(\\s*\\.(struct|enum|proc|scope|macro|define)\\s+)' + searchWord + '\\b', 'i');
+}
 
 /**
  * Searches any reference for a given word (label).

--- a/src/regexes.ts
+++ b/src/regexes.ts
@@ -137,8 +137,9 @@ export function regexStructForWord(searchWord: string): RegExp {
  *  1 = preceding characters before 'searchWord'.
  * Used by DefinitionProvider, HoverProvider.
  */
-export function regexCA65DirectiveForWord(searchWord: string): RegExp {
-    return new RegExp('^(\\s*\\.(struct|enum|proc|scope|macro|define)\\s+)' + searchWord + '\\b', 'i');
+export function regexCA65DirectiveForWord(searchWord: string, partialWord: boolean = false): RegExp {
+    const end = partialWord ? "[\\w\\.]*\\b" : "\\b";
+    return new RegExp(`^(\\s*\\.(struct|enum|proc|scope|macro|define)\\s+)${searchWord}${end}`, 'i');
 }
 
 /**


### PR DESCRIPTION
Based on the supported syntaxes it seems like this extension is mainly used for Z80 family assembly. I've been using it for some 6502 programming though and it mostly works for this use case, save for a few directives of my assembler of choice ([CA65](https://www.cc65.org/doc/ca65.html)).

Namely, with CA65 it's possible to define a subroutine as follows:

```asm
.proc MySubroutine
    ; Some code
    rts
.endproc
```

This is the same as

```asm
MySubroutine:
.scope MySubroutine
    ; Some code
    rts
.endscope
```

The benefit is that symbols defined in these scopes won't clash with other scopes, so you can have generic labels like `loop:` without problems. Currently, asm-code-lens' features don't work when using these directives (and some others).

This PR adds hover and go-to-definition support for `.struct`, `.enum`, `.proc`, `.scope`, `.macro`, and `.define`.