### PR TITLE
Activate only when assembly is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "Programming Languages"
     ],
     "activationEvents": [
-        "*"
+        "onLanguage:asm-collection"
     ],
     "main": "./out/src/extension",
     "contributes": {


### PR DESCRIPTION
Fixed the activation events it should never be set to * as it means the extension is always activated even if you are not working on assembly files