### PR TITLE
Add syntax highlight to Markdown code blocks

### DIFF
--- a/grammar/asm_markdown_codeblock.json
+++ b/grammar/asm_markdown_codeblock.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#asm-markdown-codeblock"
+    }
+  ],
+  "repository": {
+    "asm-markdown-codeblock": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(asm)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.asm",
+          "patterns": [
+            {
+              "include": "source.asm"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.asm.codeblock"
+}

--- a/package.json
+++ b/package.json
@@ -188,6 +188,9 @@
                     "Assembler file"
                 ],
                 "configuration": "./language-configuration.json"
+            },
+            {
+              "id": "asm-markdown-codeblock"
             }
         ],
         "grammars": [
@@ -195,6 +198,14 @@
                 "language": "asm-collection",
                 "scopeName": "source.asm",
                 "path": "./grammar/asm.json"
+            },
+            {
+                "language": "asm-markdown-codeblock",
+                "scopeName": "markdown.asm.codeblock",
+                "path": "./grammar/asm_markdown_codeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ]
             }
         ],
         "problemMatchers": [


### PR DESCRIPTION
Based on [64kramsystem/vscode-fenced-code-block-grammar-injections](https://github.com/64kramsystem/vscode-fenced-code-block-grammar-injections), which in turn is based on [mjbvz/vscode-fenced-code-block-grammar-injection-example](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example).

Closes #63.