### PR TITLE
Enable breakpoints in assembly files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
     ],
     "main": "./out/src/extension",
     "contributes": {
+        "breakpoints": [
+            {
+                "language": "asm-collection"
+            }
+        ],
         "views": {
             "explorer": [
                 {


### PR DESCRIPTION
This edit allows breakpoints in assembly files, which allows for much better debug experience. I've tried this with NASM and the vscode C/C++ debugger and it worked perfectly.