### PR TITLE
Fix multiple-hash comment highlighting

### DIFF
--- a/grammar/asm.json
+++ b/grammar/asm.json
@@ -55,7 +55,7 @@
 				},
 				{
 					"name": "comment.line_hashtag.asm",
-					"begin": "#\\s",
+					"begin": "#+\\s",
 					"end": "\\n"
 				}
 			]


### PR DESCRIPTION
LLVM will sometimes add comments with two hash signs (not sure why).

### Before:
<img width="439" alt="Screen Shot 2022-10-05 at 5 35 10 PM" src="https://user-images.githubusercontent.com/70904/194188244-106a041e-d0d8-4c18-bf0a-40bfb860f140.png">

### After:
<img width="429" alt="Screen Shot 2022-10-05 at 4 42 31 PM" src="https://user-images.githubusercontent.com/70904/194188260-77d3dd54-2a0d-47e6-82ee-49fc95798d9c.png">

