### PR TITLE
File lines permalinks

### DIFF
--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -82,7 +82,7 @@ export class Commands {
                 if (count == 0) {
                     // No reference
                     unrefLabels++;
-                    output.appendLine(label + ", file://" + fileName + "#" + (pos.line + 1));
+                    output.appendLine(label + ", file://" + fileName + ":" + (pos.line + 1));
                 }
                 // Check for last search
                 labelsCount--;


### PR DESCRIPTION
Links to unreferenced label not work in vs code. It cause by file#line notation, when file:line expected. But I don`t sure that it works for all vs code configuration, so it is possible to output two variants with "#" and ":" references