### PR TITLE
Properly show symbol kinds and structs/modules in document outline

### DIFF
--- a/src/DocumentSymbolProvider.ts
+++ b/src/DocumentSymbolProvider.ts
@@ -47,7 +47,6 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         let lastSymbols = new Array<vscode.DocumentSymbol>();
         let lastAbsSymbolChildren;
         let lastModules = new Array<vscode.DocumentSymbol>();
-        let defaultSymbolKind = vscode.SymbolKind.Function;
 
         // Strip all comments
         const lines = document.getText().split('\n');
@@ -72,7 +71,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
                     const selRange = range; //new vscode.Range(line, 0, line, 3);
 
                     // Create Symbol
-                    lastSymbol = new vscode.DocumentSymbol(label, '', defaultSymbolKind, range, selRange);
+                    lastSymbol = new vscode.DocumentSymbol(label, '', vscode.SymbolKind.Function, range, selRange);
                     lastSymbols.push(lastSymbol);
 
                     // Insert as absolute or relative label
@@ -114,8 +113,8 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
                     const range = new vscode.Range(line, 0, line, 10000);
                     const macroSymbol = new vscode.DocumentSymbol(macroName, '', vscode.SymbolKind.Method, range, range);
                     symbols.push(macroSymbol);
+                    continue;
                 }
-                continue;
             }
 
             // Now check for MODULE or STRUCT
@@ -160,8 +159,6 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             lineContents = lineContents.trim();
             // Now check which kind of data it is:
             // code, const or data
-            if (!lineContents)
-                defaultSymbolKind = vscode.SymbolKind.Function;
             if (lastSymbol) {
                 if (lineContents) {
                     let kind;
@@ -186,9 +183,8 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
                             elem.kind = kind;
                             elem.detail = match![1] + ' ' + match![2].trimEnd();
                         }
-                        defaultSymbolKind = kind;
                     }
-                    // Something different, so assume code
+
                     lastSymbol = undefined;
                     lastSymbols.length = 0;
                     continue;


### PR DESCRIPTION
While trying to understand the details of `DocumentSymbolProvider`, I found these small mistakes.

1. If a regex for macros is defined (true for all language IDs other than `asm-list-file`) then processing of modules, structs, and symbol kinds is skipped.
    * Before
    ![image](https://user-images.githubusercontent.com/9356790/226221178-4e09d0d3-8978-478c-90d6-acf64043baea.png)
    * After
    ![image](https://user-images.githubusercontent.com/9356790/226221240-13f75f60-b4f5-4e9b-a1ae-b742447e2556.png)

2. If a label immediately follows a constant or data symbol, then the wrong symbol kind is used.
    * Example
    ![image](https://user-images.githubusercontent.com/9356790/226221328-e5c807f2-754d-44af-8984-46067ad5b2db.png)
    * Before
    ![image](https://user-images.githubusercontent.com/9356790/226221605-775eb2ba-29ed-4245-be96-d29b27805caa.png)
    * After
    ![image](https://user-images.githubusercontent.com/9356790/226221581-5ec3d609-766f-4fba-aedd-120fa6ecf488.png)

For the screenshots, I used `tests/modulesstruct.asm`.