### PR TITLE
Delay activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "categories": [
         "Programming Languages"
     ],
-    "activationEvents": [
-        "onStartupFinished"
-    ],
+    "activationEvents": [],
     "main": "./out/extension.js",
     "contributes": {
         "views": {


### PR DESCRIPTION
This PR changes `activationEvents` from `onStartupFinished` to `onLanguage:...`, which will be generated automatically since VSCode 1.74, so omitted.

Reference: https://code.visualstudio.com/api/references/activation-events#onLanguage